### PR TITLE
Fix problem deletion route in frontend

### DIFF
--- a/templates/pages/problem/detail.html
+++ b/templates/pages/problem/detail.html
@@ -471,7 +471,7 @@ function initializeEnhancedButtons() {
 
 function deleteProblem(slug) {
     if (confirm('Are you sure you want to delete this problem? This action cannot be undone.')) {
-        fetch(`/api/problem/${slug}`, { method: 'DELETE' })
+        fetch(`/api/problem/${slug}/delete`, { method: 'DELETE' })
             .then(async response => {
                 const text = await response.text();
                 try {


### PR DESCRIPTION
## Summary
- Point problem deletion fetch request to `/api/problem/<slug>/delete` to match backend route

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7545abbb48329afff6722ad47ebf1