### PR TITLE
Enable LaTeX rendering in problem statements

### DIFF
--- a/TUTORIAL/04-problem-statements.md
+++ b/TUTORIAL/04-problem-statements.md
@@ -214,6 +214,28 @@ Use for additional clarifications:
 - Use `a[i]` for array elements
 ```
 
+### LaTeX Math Support
+ShahOJ renders mathematical formulas using [KaTeX](https://katex.org). Use `$...$` for inline expressions and `$$...$$` for display math.
+
+**Inline example**
+```markdown
+Euler's identity: $e^{i\pi} + 1 = 0$
+```
+
+**Block example**
+```markdown
+$$
+\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+$$
+```
+
+**Complex formatting**
+```markdown
+$$
+\underbrace{f(k)}_{\text{maybe huge in }k} \times \underbrace{n^{c}}_{\text{polynomial in input size}}
+$$
+```
+
 ## 📚 Problem Types and Templates
 
 ### 1. Array Problems

--- a/core/ai_service.py
+++ b/core/ai_service.py
@@ -392,7 +392,7 @@ Create a complete markdown document with the following structure:
 ## Explanation
 [Brief explanation of sample cases if helpful]
 
-CRITICAL: Use proper mathematical notation throughout (a₁, a₂, ..., aₙ, 10⁹, ≤, ≥). Return complete markdown in the 'code' field.
+CRITICAL: Use proper mathematical notation throughout (a₁, a₂, ..., aₙ, 10⁹, ≤, ≥). Use LaTeX for all math expressions – `$...$` for inline math and `$$...$$` for block math. Return complete markdown in the 'code' field.
 """
 
 

--- a/templates/pages/problem/detail.html
+++ b/templates/pages/problem/detail.html
@@ -4,6 +4,7 @@
 {% block title %}{{ problem.config.get('title', problem.slug) }} - ShahOJ{% endblock %}
 
 {% block extra_css %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css">
 <style>
     :root {
         --primary-color: #007bff;
@@ -339,6 +340,9 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/contrib/auto-render.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Load problem statement
@@ -354,9 +358,20 @@ function loadProblemStatement() {
         .then(data => {
             const statementDiv = document.getElementById('problemStatement');
             if (data.success) {
-                // Convert markdown to HTML (simple conversion for now)
-                const htmlContent = convertMarkdownToHtml(data.statement);
-                statementDiv.innerHTML = htmlContent;
+                const htmlContent = marked.parse(data.statement);
+                statementDiv.innerHTML = `<div class="markdown-content">${htmlContent}</div>`;
+                enhanceCodeBlocks(statementDiv);
+                if (window.renderMathInElement) {
+                    renderMathInElement(statementDiv, {
+                        delimiters: [
+                            { left: '$$', right: '$$', display: true },
+                            { left: '\\(', right: '\\)', display: false },
+                            { left: '\\[', right: '\\]', display: true },
+                            { left: '$', right: '$', display: false }
+                        ],
+                        throwOnError: false
+                    });
+                }
             } else {
                 statementDiv.innerHTML = `
                     <div class="alert alert-warning">
@@ -381,79 +396,35 @@ function loadProblemStatement() {
         });
 }
 
-function convertMarkdownToHtml(markdown) {
-    // Enhanced markdown conversion
-    let html = markdown;
-    
-    // Handle code blocks first (before other processing)
-    html = html.replace(/```([^`\n]*)\n?([\s\S]*?)```/gm, function(match, lang, code) {
-        const codeId = 'code-' + Math.random().toString(36).substr(2, 9);
-        return `<div class="code-block-container position-relative mb-3">
-            <pre class="bg-light border rounded p-3 mb-0"><code id="${codeId}" class="language-${lang || 'text'}">${code.trim()}</code></pre>
-            <button class="btn btn-sm btn-outline-secondary copy-btn position-absolute" 
-                    style="top: 8px; right: 8px; padding: 4px 8px; font-size: 12px;"
-                    onclick="copyCodeBlock('${codeId}')" 
-                    title="Copy to clipboard">
-                <i class="fas fa-copy"></i>
-            </button>
-        </div>`;
+function enhanceCodeBlocks(container) {
+    container.querySelectorAll('pre > code').forEach(codeBlock => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'code-block-container position-relative mb-3';
+        const pre = codeBlock.parentNode;
+        pre.classList.add('bg-light', 'border', 'rounded', 'p-3', 'mb-0');
+        pre.parentNode.replaceChild(wrapper, pre);
+        wrapper.appendChild(pre);
+
+        const copyBtn = document.createElement('button');
+        copyBtn.className = 'btn btn-sm btn-outline-secondary copy-btn position-absolute';
+        copyBtn.style.top = '8px';
+        copyBtn.style.right = '8px';
+        copyBtn.style.padding = '4px 8px';
+        copyBtn.style.fontSize = '12px';
+        copyBtn.innerHTML = '<i class="fas fa-copy"></i>';
+        copyBtn.addEventListener('click', () => copyCodeBlock(codeBlock, copyBtn));
+        wrapper.appendChild(copyBtn);
     });
-    
-    // Handle inline code
-    html = html.replace(/`([^`]+)`/g, '<code class="bg-light px-1 rounded">$1</code>');
-    
-    // Handle headers
-    html = html.replace(/^##### (.+)$/gm, '<h5 class="mt-4 mb-2">$1</h5>');
-    html = html.replace(/^#### (.+)$/gm, '<h4 class="mt-4 mb-3">$1</h4>');
-    html = html.replace(/^### (.+)$/gm, '<h3 class="mt-4 mb-3">$1</h3>');
-    html = html.replace(/^## (.+)$/gm, '<h2 class="mt-4 mb-3">$1</h2>');
-    html = html.replace(/^# (.+)$/gm, '<h1 class="mt-3 mb-4">$1</h1>');
-    
-    // Handle bold and italic
-    html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-    html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>');
-    
-    // Handle bullet lists
-    html = html.replace(/^- (.+)$/gm, '###LISTITEM###$1###/LISTITEM###');
-    
-    // Handle numbered lists  
-    html = html.replace(/^\d+\. (.+)$/gm, '###ORDEREDITEM###$1###/ORDEREDITEM###');
-    
-    // Convert list items to proper HTML
-    html = html.replace(/(###LISTITEM###.+?###\/LISTITEM###(\n|$))+/gm, function(match) {
-        const items = match.replace(/###LISTITEM###/g, '<li>').replace(/###\/LISTITEM###/g, '</li>').trim();
-        return '<ul class="mb-3">' + items + '</ul>';
+}
+
+function copyCodeBlock(codeElement, button) {
+    const text = codeElement.textContent;
+    navigator.clipboard.writeText(text).then(() => {
+        button.innerHTML = '<i class="fas fa-check"></i>';
+        setTimeout(() => {
+            button.innerHTML = '<i class="fas fa-copy"></i>';
+        }, 2000);
     });
-    
-    html = html.replace(/(###ORDEREDITEM###.+?###\/ORDEREDITEM###(\n|$))+/gm, function(match) {
-        const items = match.replace(/###ORDEREDITEM###/g, '<li>').replace(/###\/ORDEREDITEM###/g, '</li>').trim();
-        return '<ol class="mb-3">' + items + '</ol>';
-    });
-    
-    // Handle mathematical notation (common in competitive programming)
-    html = html.replace(/≤/g, '&le;');
-    html = html.replace(/≥/g, '&ge;');
-    html = html.replace(/\^(\d+)/g, '<sup>$1</sup>');
-    
-    // Handle paragraphs - split by double newlines
-    const paragraphs = html.split(/\n\s*\n/);
-    html = paragraphs.map(p => {
-        p = p.trim();
-        if (!p) return '';
-        
-        // Skip if already wrapped in block elements
-        if (p.match(/^<(h[1-6]|pre|ul|ol|div)/)) {
-            return p;
-        }
-        
-        // Wrap in paragraph
-        return `<p class="mb-3">${p}</p>`;
-    }).join('\n');
-    
-    // Clean up extra whitespace
-    html = html.replace(/\n+/g, '\n').trim();
-    
-    return `<div class="markdown-content">${html}</div>`;
 }
 
 function initializeEnhancedButtons() {
@@ -496,48 +467,6 @@ function deleteProblem(slug) {
 function exportProblem(slug) {
     // Placeholder for export functionality
     alert('Export functionality will be implemented soon!');
-}
-
-function copyCodeBlock(codeId) {
-    const codeElement = document.getElementById(codeId);
-    const button = event.target.closest('.copy-btn');
-    
-    if (!codeElement) return;
-    
-    // Get the text content
-    const text = codeElement.textContent;
-    
-    // Copy to clipboard
-    navigator.clipboard.writeText(text).then(() => {
-        // Show success feedback
-        const originalContent = button.innerHTML;
-        button.innerHTML = '<i class="fas fa-check"></i>';
-        button.classList.add('copied');
-        
-        // Reset after 2 seconds
-        setTimeout(() => {
-            button.innerHTML = originalContent;
-            button.classList.remove('copied');
-        }, 2000);
-    }).catch(err => {
-        // Fallback for older browsers
-        const textArea = document.createElement('textarea');
-        textArea.value = text;
-        document.body.appendChild(textArea);
-        textArea.select();
-        document.execCommand('copy');
-        document.body.removeChild(textArea);
-        
-        // Show success feedback
-        const originalContent = button.innerHTML;
-        button.innerHTML = '<i class="fas fa-check"></i>';
-        button.classList.add('copied');
-        
-        setTimeout(() => {
-            button.innerHTML = originalContent;
-            button.classList.remove('copied');
-        }, 2000);
-    });
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- parse markdown with marked.js and render math via KaTeX
- add documentation examples for inline, block, and complex LaTeX

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c759b729208329922f9648cce76e07